### PR TITLE
Check for robots.txt

### DIFF
--- a/twa
+++ b/twa
@@ -397,11 +397,13 @@ function stage_4_scm_repos {
 function stage_5_robots_check {
   verbose "Stage 5: Robots Exclusion Protocol check"
 
-  http_response_code=$(curl -L -s -o /dev/null -w "%{http_code}" "${domain}/robots.txt")
-  if [[ ${http_response_code} == 200 ]]; then
-    PASS "Robots.txt is provided at: ${domain}/robots.txt"
-  else
+  code=$(fetch_respcode "${domain}/robots.txt")
+  if [[ "${code}" -eq 200 ]]; then
+    PASS "Site provides robots.txt at: ${domain}/robots.txt"
+  elif [[ "${code}" -eq 404 ]]; then
     MEH "No robots file found at: ${domain}/robots.txt"
+  else
+    UNK "Got a weird response code (${code}) when testing for robots.txt at: ${domain}/robots.txt"
   fi
 }
 

--- a/twa
+++ b/twa
@@ -390,8 +390,22 @@ function stage_4_scm_repos {
   done
 }
 
+# Stage 5: Check if the server provides a robots.txt file.
+#
+# Check for "The Robots Exclusion Protocol".
+# Will follow redirects to ensure file exists.
+function stage_5_robots_check {
+  verbose "Stage 5: Robots Exclusion Protocol check"
 
-# Some ideas for a fifth stage:
+  http_response_code=$(curl -L -s -o /dev/null -w "%{http_code}" "${domain}/robots.txt")
+  if [[ ${http_response_code} == 200 ]]; then
+    PASS "Robots.txt is provided at: ${domain}/robots.txt"
+  else
+    MEH "No robots file found at: ${domain}/robots.txt"
+  fi
+}
+
+# Some ideas for a sixth stage:
 # * `dig +short caa $domain`
 #   * Good: They specify an issuer.
 #   * Meh: They specify an known bad issuer, or they specifically disallow all issuers.
@@ -433,4 +447,5 @@ stage_1_redirection
 stage_2_security_headers
 stage_3_information_disclosure
 stage_4_scm_repos
+stage_5_robots_check
 


### PR DESCRIPTION
This adds another stage to check if the site has a `robots.txt` file. It doesn't check what info it contains, only if the file exists. The condition is tested based on HTTP response code received  from the server and it will follow `301` redirects. If a `robots.txt` file does exist, it will get a PASS, if not, it will get a MEH. It's absence from the server is not a security risk and will not receive a FAIL or FATAL.