### PR TITLE
twa: Formal codes for negative results

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ You'll need `bash` 4, `curl`, `dig`, and `nc`, along with a fairly POSIX system.
 ```bash
 # Audit a site.
 $ twa google.com
-> FAIL(google.com): HTTP redirects to HTTP (not secure)
-> FAIL(google.com): Strict-Transport-Security missing
-> MEH(google.com): X-Frame-Options is 'sameorigin', consider 'deny'?
-> FAIL(google.com): X-Content-Type-Options missing
+> FAIL(google.com): TWA-0102: HTTP redirects to HTTP (not secure)
+> FAIL(google.com): TWA-0205: Strict-Transport-Security missing
+> MEH(google.com): TWA-0206: X-Frame-Options is 'sameorigin', consider 'deny'
+> FAIL(google.com): TWA-0209: X-Content-Type-Options missing
 > PASS(google.com): X-XSS-Protection specifies mode=block
-> FAIL(google.com): Referrer-Policy missing
-> FAIL(google.com): Content-Security-Policy missing
-> FAIL(google.com): Feature-Policy missing
+> FAIL(google.com): TWA-0214: Referrer-Policy missing
+> FAIL(google.com): TWA-0219: Content-Security-Policy missing
+> FAIL(google.com): TWA-0220: Feature-Policy missing
 > PASS(google.com): Site sends 'Server', but probably only a vendor ID: gws
 > PASS(google.com): Site doesn't send 'X-Powered-By'
 > PASS(google.com): Site doesn't send 'Via'
@@ -34,6 +34,8 @@ $ twa google.com
 > PASS(google.com): No SCM repository at: http://google.com/.git/HEAD
 > PASS(google.com): No SCM repository at: http://google.com/.hg/store/00manifest.i
 > PASS(google.com): No SCM repository at: http://google.com/.svn/entries
+> PASS(google.com): No environment file at: http://google.com/.env
+> PASS(google.com): No environment file at: http://google.com/.dockerenv
 
 # Audit a site, and be verbose.
 $ twa -v google.com
@@ -59,6 +61,10 @@ where `TYPE` is one of `PASS`, `MEH`, `FAIL`, `UNK`, `SKIP`, and `FATAL`:
 * `UNK`: The server gave us something we didn't understand.
 * `SKIP`: The server gave us something we understood, but that we don't handle yet.
 * `FATAL`: A really important test failed, and should be fixed immediately.
+
+If the `TYPE` is negative (i.e. `MEH`, `FAIL`, or `FATAL`), the explanation will be prefixed with
+a reference code with the format `TWA-XXYY`, where `XX` is the stage that the result occurred in
+and `YY` is a unique identifier for the result.
 
 ### Scoring
 

--- a/twa
+++ b/twa
@@ -9,6 +9,71 @@ TWA_VERSION="1.5.1"
 TWA_TIMEOUT="${TWA_TIMEOUT:-5}"
 read -r -a TWA_CURLOPTS <<< "${TWA_CURLOPTS}"
 
+declare -A TWA_CODES=(
+  # Stage 0
+  [TWA-0001]="Expected port 443 to be open, but it isn't"
+
+  # Stage 1
+  [TWA-0101]="HTTP redirects to HTTPS using a 302"
+  [TWA-0102]="HTTP redirects to HTTP (not secure)"
+  [TWA-0103]="HTTP doesn't redirect at all"
+
+  # Stage 2
+  [TWA-0201]="Skipping security checks due to no secure channel"
+  [TWA-0202]="Strict-Transport-Security max-age is less than 6 months"
+  [TWA-0203]="Strict-Transport-Security, but no includeSubDomains"
+  [TWA-0204]="Strict-Transport-Security, but no preload"
+  [TWA-0205]="Strict-Transport-Security missing"
+  [TWA-0206]="X-Frame-Options is 'sameorigin', consider 'deny'"
+  [TWA-0207]="X-Frame-Options is 'allow-from', consider 'deny' or 'none'"
+  [TWA-0208]="X-Frame-Options missing"
+  [TWA-0209]="X-Content-Type-Options missing"
+  [TWA-0210]="X-XSS-Protection is '0'; XSS filtering disabled"
+  [TWA-0211]="X-XSS-Protection sanitizes but doesn't block, consider mode=block?"
+  [TWA-0212]="X-XSS-Protection missing"
+  [TWA-0213]="Referrer-Policy specifies '\${rp}', consider 'no-referrer'?"
+  [TWA-0214]="Referrer-Policy missing"
+  [TWA-0215]="Content-Security-Policy 'default-src' is '\${csp_default_src}'"
+  [TWA-0216]="Content-Security-Policy 'default-src' is missing"
+  [TWA-0217]="Content-Security-Policy has one or more 'unsafe-inline' policies"
+  [TWA-0218]="Content-Security-Policy has one or more 'unsafe-eval' policies"
+  [TWA-0219]="Content-Security-Policy missing"
+  [TWA-0220]="Feature-Policy missing"
+
+  # Stage 3
+  [TWA-0301]="Site sends 'Server' with what looks like a version tag: \${server}"
+  [TWA-0302]="Site sends a long 'Server', probably disclosing version info: \${server}"
+  [TWA-0303]="Site sends '\${badheader}, probably disclosing version info: \${content}'"
+
+  # Stage 4
+  [TWA-0401]="SCM repository being served at: \${url}"
+  [TWA-0402]="Possible SCM repository being served (maybe protected?) at: \${url}"
+  [TWA-0403]="Environment file being served at: \${url}"
+  [TWA-0404]="Possible environment file being served (maybe protected?) at: \${url}"
+
+  # Stage 5
+  [TWA-0501]="No robots file found at: \${domain}/robots.txt"
+  [TWA-0502]="robots.txt lists what looks like an admin panel"
+  [TWA-0503]="robots.txt lists what looks like CGI scripts"
+
+  # Stage 6
+  [TWA-0601]="No CAA records found"
+  [TWA-0602]="Domain doesn't specify any valid issuers"
+  [TWA-0603]="Domain explicitly disallows all issuers"
+  [TWA-0604]="Domain doesn't specify any violation reporting endpoints"
+
+  # Stage 7
+  [TWA-0701]="Domain is listening on a development/backend port: \${dev_port}"
+
+  # Stage 8
+  [TWA-0801]="cookie '\${cookie_name}' has 'secure' but no 'httponly' flag"
+  [TWA-0802]="cookie '\${cookie_name}' has no 'secure' flag"
+)
+
+# If we're being sourced, stop execution here.
+# You can use this to read `TWA_CODES` above via `source` in other programs.
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] || return
+
 # TTY check to prevent breaking scripts
 # Respect the "NO_COLOR spec"
 if [[ -t 1 && -z "${NO_COLOR}" ]]; then
@@ -91,52 +156,55 @@ function output {
     message="${3//\"/\"\"}"
     message="\"${message}\""
 
-    echo "${1},${2},${message}";
+    echo "${1},${2},${message},${4}"
   else
     # default is ANSI
     # colorize first arg
     first="";
     if [ "${1}" == "PASS" ]; then
-      first="${TWA_COLOR_GREEN}${1}${TWA_COLOR_RESET}";
+      first="${TWA_COLOR_GREEN}${1}${TWA_COLOR_RESET}"
     elif [ "${1}" == "MEH" ]; then
-      first="${TWA_COLOR_BLUE}${1}${TWA_COLOR_RESET}";
+      first="${TWA_COLOR_BLUE}${1}${TWA_COLOR_RESET}"
     elif [ "${1}" == "FAIL" ] || [ "${1}" == "FATAL" ]; then
-      first="${TWA_COLOR_RED}${1}${TWA_COLOR_RESET}";
+      first="${TWA_COLOR_RED}${1}${TWA_COLOR_RESET}"
     elif [ "${1}" == "UNK" ] || [ "${1}" == "SKIP" ]; then
-      first="${TWA_COLOR_PURPLE}${1}${TWA_COLOR_RESET}";
+      first="${TWA_COLOR_PURPLE}${1}${TWA_COLOR_RESET}"
     fi;
-    echo -e "$first(${2}): ${3}";
+    echo -e "$first(${2}): ${3}"
   fi;
 }
 
 # PASS: A test passed with flying colors (nothing wrong at all).
 function PASS {
-  output "PASS" "${domain}" "$*";
+  output "PASS" "${domain}" "${1}"
 }
 
 # MEH: A test passed, but with one or more things that could be improved.
 function MEH {
-  output "MEH" "${domain}" "$*";
+  msg=$(eval "echo \"${1}: ${TWA_CODES[${1}]}\"")
+  output "MEH" "${domain}" "${msg}" "${1}"
 }
 
 # FAIL: A test failed, and should be fixed.
 function FAIL {
-  output "FAIL" "${domain}" "$*";
+  msg=$(eval "echo \"${1}: ${TWA_CODES[${1}]}\"")
+  output "FAIL" "${domain}" "${msg}" "${1}"
 }
 
 # FATAL: A really important test failed, and should be fixed immediately.
 function FATAL {
-  output "FATAL" "${domain}" "$*";
+  msg=$(eval "echo \"${1}: ${TWA_CODES[${1}]}\"")
+  output "FATAL" "${domain}" "${msg}" "${1}"
 }
 
 # UNK: The server gave us something we didn't understand.
 function UNK {
-  output "UNK" "${domain}" "$*";
+  output "UNK" "${domain}" "${1}"
 }
 
 # SKIP: This test hasn't been implemented yet.
 function SKIP {
-  output "SKIP" "${domain}" "$*";
+  output "SKIP" "${domain}" "${1}"
 }
 
 
@@ -153,7 +221,7 @@ function stage_0_has_https {
 
   # First, just probe the domain to see if it listens on 443.
   if ! probe "${domain}" 443 ; then
-    FATAL "expected port 443 to be open, but it isn't"
+    FATAL TWA-0001
     no_https=1 ; return
   fi
 
@@ -197,14 +265,14 @@ function stage_1_redirection {
     if [[ "${response}" == 301 ]]; then
       PASS "HTTP redirects to HTTPS using a 301"
     elif [[ "${response}" == 302 ]]; then
-      MEH "HTTP redirects to HTTPS using a 302"
+      MEH TWA-0101
     else
       UNK "HTTP sends an HTTPS location but with a weird response code: ${response}"
     fi
   elif [[ "${location}" =~ ^http ]]; then
-    FAIL "HTTP redirects to HTTP (not secure)"
+    FAIL TWA-0102
   else
-    FAIL "HTTP doesn't redirect at all"
+    FAIL TWA-0103
   fi
 }
 
@@ -224,7 +292,7 @@ function stage_2_security_headers {
   verbose "Stage 2: Sane security headers"
 
   if [[ -n "${no_https}" ]]; then
-    FATAL "skipping security header checks due to no secure channel"
+    FATAL TWA-0201
     return
   fi
 
@@ -240,7 +308,7 @@ function stage_2_security_headers {
       if [[ "${sts_max_age}" -ge 15768000 ]]; then
         PASS "Strict-Transport-Security max-age is at least 6 months"
       else
-        MEH "Strict-Transport-Security max-age is less than 6 months"
+        MEH TWA-0202
       fi
     else
       UNK "Strict-Transport-Security received, but no max-age"
@@ -249,16 +317,16 @@ function stage_2_security_headers {
     if [[ -n "${sts_incl_subs}" ]]; then
       PASS "Strict-Transport-Security specifies includeSubDomains"
     else
-      MEH "Strict-Transport-Security, but no includeSubDomains"
+      MEH TWA-0203
     fi
 
     if [[ -n "${sts_preload}" ]]; then
       PASS "Strict-Transport-Security specifies preload"
     else
-      MEH "Strict-Transport-Security, but no preload"
+      MEH TWA-0204
     fi
   else
-    FAIL "Strict-Transport-Security missing"
+    FAIL TWA-0205
   fi
 
   xfo=$(get_header "X-Frame-Options" <<< "${headers}")
@@ -268,14 +336,14 @@ function stage_2_security_headers {
     if [[ "${xfo}" == "deny" ]]; then
       PASS "X-Frame-Options is 'deny'"
     elif [[ "${xfo}" == "sameorigin" ]]; then
-      MEH "X-Frame-Options is 'sameorigin', consider 'deny'?"
+      MEH TWA-0206
     elif [[ "${xfo}" =~ ^allow-from ]]; then
-      MEH "X-Frame-Options is 'allow-from', consider 'deny' or 'none'?"
+      MEH TWA-0207
     else
       UNK "X-Frame-Options set to something weird: ${xfo}"
     fi
   else
-    FAIL "X-Frame-Options missing"
+    FAIL TWA-0208
   fi
 
   xcto=$(get_header "X-Content-Type-Options" <<< "${headers}")
@@ -287,7 +355,7 @@ function stage_2_security_headers {
       UNK "X-Content-Type-Options set to something weird: ${xcto}"
     fi
   else
-    FAIL "X-Content-Type-Options missing"
+    FAIL TWA-0209
   fi
 
   xxp=$(get_header "X-XSS-Protection" <<< "${headers}")
@@ -295,16 +363,16 @@ function stage_2_security_headers {
 
   if [[ -n "${xxp}" ]]; then
     if [[ "${xxp}" == 0 ]]; then
-      FAIL "X-XSS-Protection is '0'; XSS filtering disabled"
+      FAIL TWA-0210
     elif [[ "${xxp}" =~ ^1 ]]; then
       if [[ "${xxp}" =~ mode=block ]]; then
         PASS "X-XSS-Protection specifies mode=block"
       else
-        MEH "X-XSS-Protection sanitizes but doesn't block, consider mode=block?"
+        MEH TWA-0211
       fi
     fi
   else
-    FAIL "X-XSS-Protection missing"
+    FAIL TWA-0212
   fi
 
   rp=$(get_header "Referrer-Policy" <<< "${headers}")
@@ -319,10 +387,10 @@ function stage_2_security_headers {
             || "${rp}" == "origin-when-cross-origin"
             || "${rp}" == "same-origin"
             || "${rp}" == "strict-origin" ]]; then
-      MEH "Referrer-Policy specifies '${rp}', consider 'no-referrer'?"
+      MEH TWA-0213
     fi
   else
-    FAIL "Referrer-Policy missing"
+    FAIL TWA-0214
   fi
 
   csp=$(get_header "Content-Security-Policy" <<< "${headers}")
@@ -333,21 +401,21 @@ function stage_2_security_headers {
       if [[ "${csp_default_src//\'}" == "none" ]]; then
         PASS "Content-Security-Policy 'default-src' is 'none'"
       else
-        MEH "Content-Security-Policy 'default-src' is ${csp_default_src}"
+        MEH TWA-0215
       fi
     else
-      FAIL "Content-Security-Policy 'default-src' is missing"
+      FAIL TWA-0216
     fi
 
     if [[ "${csp}" =~ unsafe-inline ]]; then
-      FAIL "Content-Security-Policy has one or more 'unsafe-inline' policies"
+      FAIL TWA-0217
     fi
 
     if [[ "${csp}" =~ unsafe-eval ]]; then
-      FAIL "Content-Security-Policy has one or more 'unsafe-eval' policies"
+      FAIL TWA-0218
     fi
   else
-    FAIL "Content-Security-Policy missing"
+    FAIL TWA-0219
   fi
 
   fp=$(get_header "Feature-Policy" <<< "${headers}")
@@ -355,7 +423,7 @@ function stage_2_security_headers {
   if [[ -n "${fp}" ]]; then
     SKIP "Feature-Policy checks not implemented yet"
   else
-    FAIL "Feature-Policy missing"
+    FAIL TWA-0220
   fi
 }
 
@@ -373,12 +441,12 @@ function stage_3_server_information_disclosure {
     server_wc=$(wc -w <<< "${server}")
     if [[ "${server_wc}" -le 1 ]]; then
       if [[ "${server}" == */* ]]; then
-        FAIL "Site sends 'Server' with what looks like a version tag: ${server}"
+        FAIL TWA-0301
       else
         PASS "Site sends 'Server', but probably only a vendor ID: ${server}"
       fi
     else
-      FAIL "Site sends a long 'Server', probably disclosing version info: ${server}"
+      FAIL TWA-0302
     fi
   else
     PASS "Site doesn't send 'Server' header"
@@ -388,7 +456,7 @@ function stage_3_server_information_disclosure {
     content=$(get_header "${badheader}" <<< "${headers}")
 
     if [[ -n "${content}" ]]; then
-      FAIL "Site sends '${badheader}', probably disclosing version info: ${content}"
+      FAIL TWA-0303
     else
       PASS "Site doesn't send '${badheader}'"
     fi
@@ -412,9 +480,9 @@ function stage_4_repo_and_env_disclosure {
     code=$(fetch_respcode "${url}")
 
     if [[ "${code}" -eq 200 ]]; then
-      FAIL "SCM repository being served at: ${url}"
+      FAIL TWA-0401
     elif [[ "${code}" -eq 403 ]]; then
-      MEH "Possible SCM repository being served (maybe protected?) at: ${url}"
+      MEH TWA-0402
     elif [[ "${code}" -eq 404 ]]; then
       PASS "No SCM repository at: ${url}"
     else
@@ -427,9 +495,9 @@ function stage_4_repo_and_env_disclosure {
     code=$(fetch_respcode "${url}")
 
     if [[ "${code}" -eq 200 ]]; then
-      FAIL "Environment file being served at: ${url}"
+      FAIL TWA-0403
     elif [[ "${code}" -eq 403 ]]; then
-      MEH "Possible environment file being served (maybe protected?) at: ${url}"
+      MEH TWA-0404
     elif [[ "${code}" -eq 404 ]]; then
       PASS "No environment file at: ${url}"
     else
@@ -451,15 +519,15 @@ function stage_5_robots_check {
     robots=$(fetch -L -s "${domain}/robots.txt")
 
     if [[ "${robots}" =~ .*admin.* ]]; then
-       MEH "robots.txt lists what looks like an admin panel"
+       MEH TWA-0502
     fi
 
     if [[ "${robots}" =~ .*cgi-bin.* ]]; then
-       MEH "robots.txt lists what looks like CGI scripts"
+       MEH TWA-0503
     fi
 
   elif [[ "${code}" -eq 404 ]]; then
-    MEH "No robots file found at: ${domain}/robots.txt"
+    MEH TWA-0501
   else
     UNK "Got a weird response code (${code}) when testing for robots.txt at: ${domain}/robots.txt"
   fi
@@ -514,16 +582,16 @@ function stage_6_caa {
       fi
     done <<< "${records}"
   else
-    FAIL "No CAA records found"
+    FAIL TWA-0601
     return
   fi
 
   if [[ "${#issuers[@]}" -eq 0 ]]; then
-    FAIL "Domain doesn't specify any valid issuers"
+    FAIL TWA-0602
   elif [[ "${#issuers[@]}" -eq 1 && "${issuers[0]}" == ";" ]]; then
     # NOTE(ww): If every site should have HTTPS, then every domain should have CAA
     # record(s) that specify all valid issuers for certificates.
-    FAIL "Domain explicitly disallows all issuers"
+    FAIL TWA-0603
   else
     PASS "Domain explicitly allows one or more issuers: ${issuers[*]}"
   fi
@@ -536,7 +604,7 @@ function stage_6_caa {
   if [[ "${#iodefs[@]}" -eq 0 ]]; then
     # NOTE(ww): This could be a failure, but it's more of a reporting shortcoming
     # than a security/privacy issue.
-    MEH "Domain doesn't specify any violation reporting endpoints"
+    MEH TWA-0604
   else
     PASS "Domain specifies one or more reporting endpoints: ${iodefs[*]}"
   fi
@@ -562,7 +630,7 @@ function stage_7_open_development_ports {
 
   for dev_port in "${dev_ports[@]}"; do
     if probe "${domain}" "${dev_port}"; then
-      FAIL "Domain is listening on a development/backend port: ${dev_port}"
+      FAIL TWA-0701
     else
       PASS "Domain is not listening on a development/backend port: ${dev_port}"
     fi
@@ -592,9 +660,9 @@ function stage_8_cookie_checks {
       if [[ -n "${has_secure}" && -n "${has_httponly}" ]]; then
         PASS "cookie '${cookie_name}' has both 'secure' and 'httponly' flags"
       elif [[ -n "${has_secure}" && -z "${has_httponly}" ]]; then
-        MEH "cookie '${cookie_name}' has 'secure' but no 'httponly' flag"
+        MEH TWA-0801
       else
-        FAIL "cookie '${cookie_name}' has no 'secure' flag"
+        FAIL TWA-0802
       fi
     done
 
@@ -638,7 +706,7 @@ fi
 
 # If we're in CSV mode, write some column titles.
 if [[ -n "${csv}" ]]; then
-  output status domain message
+  output status domain message code
 fi
 
 stage_0_has_https


### PR DESCRIPTION
I'm not 100% satisfied with this approach yet -- it'd be nice to avoid `eval`, plus the mixture of explanation strings (for `PASS`, `UNK`, `SKIP`) with codes (for `MEH`, `FAIL`, `FATAL`) feels a little ugly.

Closes #33.