### PR TITLE
Recognizing 308s as valid the same way as 301s in twa redirection test.

### DIFF
--- a/twa
+++ b/twa
@@ -262,8 +262,8 @@ function stage_1_redirection {
   read -r response < <(awk '/^HTTP/ { print $2 }' <<< "${headers}")
 
   if [[ "${location}" =~ ^https ]]; then
-    if [[ "${response}" == 301 ]]; then
-      PASS "HTTP redirects to HTTPS using a 301"
+    if [[ "${response}" =~ ^30[18]$ ]]; then
+      PASS "HTTP redirects to HTTPS using a ${response}"
     elif [[ "${response}" == 302 ]]; then
       MEH TWA-0101
     else


### PR DESCRIPTION
This change addresses issue #42.