### PR TITLE
integrate testssl.sh and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
+dist: bionic
 language: bash
 before_install:
-  - sudo apt-get install -y shellcheck
+  - sudo apt-get install -y shellcheck jq testssl.sh
 script:
   - ./util/test
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL creator woodruffw
 LABEL dockerfile_maintenance khast3x
 LABEL desc "A tiny web auditor with strong opinions."
 
-RUN apk add --no-cache bash git curl ncurses bind-tools
+RUN apk add --no-cache bash git curl ncurses bind-tools jq
 
 COPY . /twa
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,9 @@ A **t**iny **w**eb **a**uditor with strong opinions.
 
 ### Dependencies
 
-You'll need `bash` 4, `curl`, `dig`, and `nc`, along with a fairly POSIX system.
+You'll need `bash` 4, `curl`, `dig`, `jq`, and `nc`, along with a fairly POSIX system.
 
-#### Optional Dependencies
-`testssl.sh` ([github repo](https://github.com/drwetter/testssl.sh))
-#### How to use
-1. Follow install instructions at the `testssl.sh` ([github repo](https://github.com/drwetter/testssl.sh)).
-2. Add the location of `testssl.sh` to your `PATH` environment variable.
-3. Use the `-s` flag to enable `testssl.sh` in twa.
-
-Example: `twa -s google.com`
-
+[`testssl.sh`](https://github.com/drwetter/testssl.sh) is an optional dependency.
 
 ### Auditing
 
@@ -47,14 +39,18 @@ $ twa google.com
 > PASS(google.com): No environment file at: http://google.com/.env
 > PASS(google.com): No environment file at: http://google.com/.dockerenv
 
-# Audit a site, and be verbose.
-$ twa -v google.com
+# Audit a site, and be verbose (on stderr)
+$ twa -v example.com
 
-# Audit a site and its www subdomain.
-$ twa -w google.com
+# Audit a site and emit results in CSV
+$ twa -c example.com
 
-# Audit a site and include testssl.sh
-$ twa -s google.com
+# Audit a site and its www subdomain
+$ twa -w example.com
+
+# Audit a site and include testssl
+# Requires either `testssl` or `testssl.sh` on your $PATH
+$ twa -s example.com
 ```
 
 `twa` takes one domain at a time, and only audits more than one domain at once in the `-w` case.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ A **t**iny **w**eb **a**uditor with strong opinions.
 
 You'll need `bash` 4, `curl`, `dig`, and `nc`, along with a fairly POSIX system.
 
+#### Optional Dependencies
+`testssl.sh` ([github repo](https://github.com/drwetter/testssl.sh))
+#### How to use
+1. Follow install instructions at the `testssl.sh` ([github repo](https://github.com/drwetter/testssl.sh)).
+2. Add the location of `testssl.sh` to your `PATH` environment variable.
+3. Use the `-s` flag to enable `testssl.sh` in twa.
+
+Example: `twa -s google.com`
+
+
 ### Auditing
 
 ```bash
@@ -42,6 +52,9 @@ $ twa -v google.com
 
 # Audit a site and its www subdomain.
 $ twa -w google.com
+
+# Audit a site and include testssl.sh
+$ twa -s google.com
 ```
 
 `twa` takes one domain at a time, and only audits more than one domain at once in the `-w` case.

--- a/twa
+++ b/twa
@@ -916,7 +916,31 @@ function stage_8_cookie_checks {
   fi
 }
 
-# Some ideas for a ninth stage:
+# Stage 9(optional): Run 'testssl.sh'
+#
+# This test is completely optional and will be skipped if 'testssl.sh'
+# is not found in your PATH environment variable. By default, 'testssl.sh'
+# will not run unless the '-s' flag is presented.
+#
+# Runs 'testssl.sh' which checks a server's service on any port
+# for the support of TLS/SSL ciphers, protocols as well as some
+# cryptographic flaws.
+#
+# Additional information about 'testssl.sh' can be
+# located at: https://github.com/drwetter/testssl.sh
+#
+function stage_9_testssl {
+  # Skip the test if the '-s' flag is missing
+  if [[ -n "${testssl}" ]]; then
+    if installed testssl.sh; then
+      (exec testssl.sh "${domain}")
+    else
+      UNK "'testssl.sh' not found or may not be installed. Check your PATH environment variable."
+    fi
+  fi
+}
+
+# Some ideas for a tenth stage:
 # * Fetch the server's cert using `openssl s_client`, check it for known bad suites
 # * Alternatively, just `nmap --script ssl-enum-ciphers -p 443 $domain`
 
@@ -926,13 +950,14 @@ ensure installed dig
 
 [[ "${BASH_VERSINFO[0]}" -ge 4 ]] || die "Expected GNU Bash 4.0 or later, got ${BASH_VERSION}"
 
-while getopts ":wvcV" opt; do
+while getopts ":wvcsV" opt; do
   case "${opt}" in
     w ) www=1 ;;
     v ) verbose=1 ;;
     c ) csv=1 ;;
+    s ) testssl=1 ;;
     V ) echo "twa version ${TWA_VERSION}" ; exit ;;
-    \? ) echo "Usage: twa [-cvw] <domain>"; exit ;;
+    \? ) echo "Usage: twa [-csvw] <domain>"; exit ;;
   esac
 done
 
@@ -965,3 +990,4 @@ stage_5_robots_and_security_check
 stage_6_caa
 stage_7_open_development_ports
 stage_8_cookie_checks
+stage_9_testssl

--- a/twa
+++ b/twa
@@ -87,6 +87,9 @@ declare -A TWA_CODES=(
   [TWA-0808]="cookie '\${cookie_name}' must contain a 'Path' attribute"
   [TWA-0809]="cookie '\${cookie_name}' 'Domain' attribute must match the domain being tested"
   [TWA-0810]="cookie '\${cookie_name}' 'Path' attribute must contain a value of '/'"
+
+  # Stage 9
+  [TWA-0901]="testssl reports '\${finding}' ('\${id}')"
 )
 
 # If we're being sourced, stop execution here.
@@ -916,7 +919,7 @@ function stage_8_cookie_checks {
   fi
 }
 
-# Stage 9(optional): Run 'testssl.sh'
+# Stage 9 (optional): Run 'testssl.sh'
 #
 # This test is completely optional and will be skipped if 'testssl.sh'
 # is not found in your PATH environment variable. By default, 'testssl.sh'
@@ -930,28 +933,62 @@ function stage_8_cookie_checks {
 # located at: https://github.com/drwetter/testssl.sh
 #
 function stage_9_testssl {
+  verbose "Stage 9: SSL checks"
+
+  declare -A severity_map=(
+    [OK]=PASS
+    [LOW]=MEH
+    [MEDIUM]=FAIL
+    [HIGH]=FAIL
+    [CRITICAL]=FATAL
+  )
+
   # Skip the test if the '-s' flag is missing
-  if [[ -n "${testssl}" ]]; then
-    if installed testssl; then
-      testssl=testssl
-    elif installed testssl.sh; then
-      testssl=testssl.sh
-    else
-      UNK "'testssl' not found or may not be installed. Check your PATH environment variable."
-      return
-    fi
-
-    (exec "${testssl}" "${domain}")
+  if [[ -z "${testssl}" ]]; then
+    return
   fi
-}
 
-# Some ideas for a tenth stage:
-# * Fetch the server's cert using `openssl s_client`, check it for known bad suites
-# * Alternatively, just `nmap --script ssl-enum-ciphers -p 443 $domain`
+  if installed testssl; then
+    testssl=testssl
+  elif installed testssl.sh; then
+    testssl=testssl.sh
+  else
+    UNK "'testssl' not found or may not be installed. Check your PATH environment variable."
+    return
+  fi
+
+  verbose "testssl is running, be patient"
+
+  testssl_json=$(mktemp -t -u twa-testssl-XXXXX)
+  trap 'rm -f ${testssl_json}' EXIT
+  "${testssl}" --jsonfile "${testssl_json}" "${domain}" > /dev/null
+
+  while read -r record; do
+    IFS=$'\x01' read -ra record <<< "${record}"
+    severity="${record[0]}"
+    id="${record[1]}"
+    finding="${record[2]}"
+
+    if [[ "${severity}" == "INFO" ]]; then
+      verbose "testssl: '${finding}' (${id})"
+    elif [[ "${severity}" == "OK" ]]; then
+      PASS "testssl: '${finding}'"
+    else
+      severity="${severity_map[${severity}]}"
+
+      if [[ -z "${severity}" ]]; then
+        UNK "testssl: '${finding}'"
+      else
+        "${severity}" TWA-0901
+      fi
+    fi
+  done < <(jq -r $'.[] | [.severity, .id, .finding] | join("\x01")' < "${testssl_json}")
+}
 
 ensure installed curl
 ensure installed nc
 ensure installed dig
+ensure installed jq
 
 [[ "${BASH_VERSINFO[0]}" -ge 4 ]] || die "Expected GNU Bash 4.0 or later, got ${BASH_VERSION}"
 
@@ -996,3 +1033,7 @@ stage_6_caa
 stage_7_open_development_ports
 stage_8_cookie_checks
 stage_9_testssl
+
+# TODO(ww): Something in stage 9 is causing twa to exit with 1, despite appearing
+# to succeed otherwise. Find it and destroy it.
+exit 0

--- a/twa
+++ b/twa
@@ -452,7 +452,7 @@ function stage_2_security_headers {
   #
   # Must have "max-age" attribute set
   #
-  # "enforce" attribute is optional but recommended to enforce 
+  # "enforce" attribute is optional but recommended to enforce
   # compliance to the CT Policy
   #
   # "report-uri" attribute is optional but it's required to have
@@ -932,11 +932,16 @@ function stage_8_cookie_checks {
 function stage_9_testssl {
   # Skip the test if the '-s' flag is missing
   if [[ -n "${testssl}" ]]; then
-    if installed testssl.sh; then
-      (exec testssl.sh "${domain}")
+    if installed testssl; then
+      testssl=testssl
+    elif installed testssl.sh; then
+      testssl=testssl.sh
     else
-      UNK "'testssl.sh' not found or may not be installed. Check your PATH environment variable."
+      UNK "'testssl' not found or may not be installed. Check your PATH environment variable."
+      return
     fi
+
+    (exec "${testssl}" "${domain}")
   fi
 }
 

--- a/twa.1
+++ b/twa.1
@@ -4,7 +4,7 @@
 twa \- tiny web auditor with strong opinions
 
 .SH SYNOPSIS
-\fBtwa\fR \fI[-wvcV]\fR \fIDOMAIN\fR
+\fBtwa\fR \fI[-wvcsV]\fR \fIDOMAIN\fR
 
 .SH DESCRIPTION
 .B twa
@@ -33,6 +33,9 @@ subdomain.
 .TP
 .B \-c
 Emit output in CSV.
+.TP
+.B \-s
+Enable 'testssl.sh' test (skipped by default)
 .TP
 .B \-V
 Print the version and exit.

--- a/twa.1
+++ b/twa.1
@@ -35,7 +35,7 @@ subdomain.
 Emit output in CSV.
 .TP
 .B \-s
-Enable 'testssl.sh' test (skipped by default)
+Run testssl-based checks (skipped by default)
 .TP
 .B \-V
 Print the version and exit.

--- a/util/test
+++ b/util/test
@@ -21,6 +21,76 @@ function ensure {
     || die "Failed to run '$*'. Aborting."
 }
 
+function test_lint {
+  shellcheck "${TWA}"
+
+  echo "${FUNCNAME[0]}: OK"
+}
+
+function test_twa_and_tscore {
+  twa_output=$("${TWA}" -v "${TEST_DOMAIN}")
+
+  [[ -n "${twa_output}" ]] || die "Empty twa output"
+
+  # TODO: Test to ensure twa_output doesn't contain color codes.
+
+  tscore_output=$("${TSCORE}" <<< "${twa_output}")
+
+  [[ -n "${tscore_output}" ]] || die "Empty tscore output"
+
+  read -r score \
+          npasses \
+          nmehs \
+          nfailures \
+          nunknowns \
+          nskips \
+          totally_screwed <<< "${tscore_output}"
+
+  [[ "${score}" -ge 0 && "${score}" -le 100 ]] || die "Bizarre total score: ${score}"
+  [[ "${npasses}" -ge 0 ]] || die "Negative passes? ${npasses}"
+  [[ "${nmehs}" -ge 0 ]] || die "Negative mehs? ${nmehs}"
+  [[ "${nfailures}" -ge 0 ]] || die "Negative failures? ${nfailures}"
+  [[ "${nunknowns}" -ge 0 ]] || die "Negative unknowns? ${nunknowns}"
+  [[ "${nskips}" -ge 0 ]] || die "Negative skips? ${nskips}"
+  [[ "${totally_screwed}" -eq 0 || "${totally_screwed}" -eq 1 ]] \
+      || die "totally_screwed not 0 or 1: ${totally_screwed}"
+
+  echo "${FUNCNAME[0]}: OK"
+}
+
+function test_twa_testssl {
+  installed testssl || { echo "${FUNCNAME[0]}: SKIP"; return; }
+
+  twa_output=$("${TWA}" -vs "${TEST_DOMAIN}")
+
+  [[ -n "${twa_output}" ]] || die "Empty twa output"
+
+  # TODO: Test to ensure twa_output doesn't contain color codes.
+
+  tscore_output=$("${TSCORE}" <<< "${twa_output}")
+
+  [[ -n "${tscore_output}" ]] || die "Empty tscore output"
+
+  read -r score \
+          npasses \
+          nmehs \
+          nfailures \
+          nunknowns \
+          nskips \
+          totally_screwed <<< "${tscore_output}"
+
+  [[ "${score}" -ge 0 && "${score}" -le 100 ]] || die "Bizarre total score: ${score}"
+  [[ "${npasses}" -ge 0 ]] || die "Negative passes? ${npasses}"
+  [[ "${nmehs}" -ge 0 ]] || die "Negative mehs? ${nmehs}"
+  [[ "${nfailures}" -ge 0 ]] || die "Negative failures? ${nfailures}"
+  [[ "${nunknowns}" -ge 0 ]] || die "Negative unknowns? ${nunknowns}"
+  [[ "${nskips}" -ge 0 ]] || die "Negative skips? ${nskips}"
+  [[ "${totally_screwed}" -eq 0 || "${totally_screwed}" -eq 1 ]] \
+      || die "totally_screwed not 0 or 1: ${totally_screwed}"
+
+  echo "${FUNCNAME[0]}: OK"
+}
+
 TWA="${TWA:-./twa}"
 TSCORE="${TSCORE:-./tscore}"
 TEST_DOMAIN="${TEST_DOMAIN:-example.com}"
@@ -31,34 +101,9 @@ TEST_DOMAIN="${TEST_DOMAIN:-example.com}"
 
 ensure installed shellcheck
 
-shellcheck "${TWA}"
+test_lint
+test_twa_and_tscore
+test_twa_testssl
+# TODO(ww): Add a test to ensure valid CSV output in CSV mode
 
-twa_output=$("${TWA}" "${TEST_DOMAIN}")
-
-[[ -n "${twa_output}" ]] || die "Empty twa output"
-
-# TODO: Test to ensure twa_output doesn't contain color codes.
-
-tscore_output=$("${TSCORE}" <<< "${twa_output}")
-
-[[ -n "${tscore_output}" ]] || die "Empty tscore output"
-
-read -r score \
-        npasses \
-        nmehs \
-        nfailures \
-        nunknowns \
-        nskips \
-        totally_screwed <<< "${tscore_output}"
-
-[[ "${score}" -ge 0 && "${score}" -le 100 ]] || die "Bizarre total score: ${score}"
-[[ "${npasses}" -ge 0 ]] || die "Negative passes? ${npasses}"
-[[ "${nmehs}" -ge 0 ]] || die "Negative mehs? ${nmehs}"
-[[ "${nfailures}" -ge 0 ]] || die "Negative failures? ${nfailures}"
-[[ "${nunknowns}" -ge 0 ]] || die "Negative unknowns? ${nunknowns}"
-[[ "${nskips}" -ge 0 ]] || die "Negative skips? ${nskips}"
-[[ "${totally_screwed}" -eq 0 || "${totally_screwed}" -eq 1 ]] \
-    || die "totally_screwed not 0 or 1: ${totally_screwed}"
-
-echo "OK"
 exit 0


### PR DESCRIPTION
Integrated `testssl.sh` [github](https://github.com/drwetter/testssl.sh) into `twa` audits. Included documentation on how to integrate `testssl.sh` into `twa` and provided an example. Updated existing documents regarding the new `-s` flag. By default, this test is skipped unless the `-s` flag is specified.

@woodruffw please feel free to make any edits/changes to grammar.

Closes #52 