### PR TITLE
convert domain name from command line into lowercase

### DIFF
--- a/twa
+++ b/twa
@@ -1023,7 +1023,9 @@ done
 
 shift $((OPTIND - 1))
 
-domain="${1}"
+# RFC4343: Domain Name System (DNS) Case Insensitivity Clarification
+# In the twa script all case insensitive compares are done by convert to lowercase.
+domain="${1,,}"
 
 [[ -n "${domain}" ]] || { usage; exit 1;  }
 [[ "${domain}" =~ ^https?:// ]] && die "Expected a bare domain, e.g. 'example.com'"


### PR DESCRIPTION
Convert domain name from command line into lowercase for case insensitive compares.

The DNS (Domain Name System) is case insensitive, see [RFC4343](https://tools.ietf.org/html/rfc4343).

In the twa script most the strings are converter to lowercase for case insensitive compares.
Now also the script argument "domain" is converter into lowercase.
So, the compare `if [[ "${domain_value}" == "${domain}" ]]; then` in line 889 is case insensitive.